### PR TITLE
Update discordSendMessage.js for discord.js v12

### DIFF
--- a/discord/discordSendMessage.js
+++ b/discord/discordSendMessage.js
@@ -16,7 +16,7 @@ module.exports = function(RED) {
                     }
                 }
                 if (channel) {
-                    var channelInstance = bot.channels.get(channel);
+                    var channelInstance = bot.channels.cache.get(channel);
                     if (channelInstance) {
 
                         let attachment = null;


### PR DESCRIPTION
Fixes: `bot.channels.get is not a function` error. 

Per [ Updating from v11 to v12](https://discordjs.guide/additional-info/changes-in-v12.html#managers-cache): 
> You will now have to directly ask for cache on a manager before trying to use collection methods